### PR TITLE
Fixed test failure (test4) by comparing maps instead of json string.

### DIFF
--- a/blade-kit/src/test/java/com/hellokaton/blade/kit/JsonKitTest.java
+++ b/blade-kit/src/test/java/com/hellokaton/blade/kit/JsonKitTest.java
@@ -64,7 +64,9 @@ public class JsonKitTest {
         childBean.setRepeatField("sss");
         String json = JsonKit.toString(childBean);
 
-        Assert.assertEquals("{\"repeatField\":\"sss\",\"childField\":\"child\",\"superField\":\"super\"}", json);
+        Map<String, Object> expectedMap = JsonKit.fromJson("{\"repeatField\":\"sss\",\"childField\":\"child\",\"superField\":\"super\"}", Map.class);
+        Map<String, Object> actualMap = JsonKit.fromJson(json, Map.class);
+        Assert.assertEquals(expectedMap, actualMap);
 
         ChildBean formJson = JsonKit.fromJson(json, ChildBean.class);
 


### PR DESCRIPTION
Created this PR to fix 1 flaky test - [test4](https://github.com/lets-blade/blade/blob/v2.1.3/blade-kit/src/test/java/com/hellokaton/blade/kit/JsonKitTest.java#L60)

--------------------------

1. **How were these test identified as flaky?**
This test was identified as flaky by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

2. **What was the error?**
When the test convert childBean to json string `String json = JsonKit.toString(childBean);`, the order of keys (i.e. repeatField, childField, superField) is not guaranteed. Thus, when we compare this String variable 'json' directly to hardcoded string `"{\"repeatField\":\"sss\",\"childField\":\"child\",\"superField\":\"super\"}"`, it may fail sometimes because the order could be different than the expected order i.e repeatField, childField, superField.

Error:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.024 s <<< FAILURE! -- in com.hellokaton.blade.kit.JsonKitTest
[ERROR] com.hellokaton.blade.kit.JsonKitTest.test4 -- Time elapsed: 0.022 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[repeatField":"sss","childField":"child]","superField":"supe...> but was:<{"[childField":"child","repeatField":"sss]","superField":"supe...>
```

3. **What is the fix?**
Instead of comparing json strings, we can convert json to Map and then compare the maps. This PR proposes to compare Maps instead of json strings in test4.

----------------------
You can run the following commands to run test4 using NonDex tool:
```
mvn -pl blade-kit edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.hellokaton.blade.kit.JsonKitTest#test4
```

Test Environment:
```
java version 11.0.19
Apache Maven 3.9.5
```
Kindly let me know if this fix is acceptable.
Thank you
